### PR TITLE
fix: 修复api.317ak.cn请求没有携带key，以及修正部分api.317ak.cn的API路径 fix: 修复响应处理的逻辑bug

### DIFF
--- a/system_api.json
+++ b/system_api.json
@@ -408,8 +408,11 @@
         "keyword": [
             "晚安"
         ],
-        "url": "http://api.317ak.cn/api/tp/zawa",
-        "type": "image"
+        "url": "http://api.317ak.cn/api/wz/waxy",
+        "type": "text",
+        "params": {
+          "type": "text"
+        }
     },
     "来点腹肌": {
         "keyword": [
@@ -723,7 +726,7 @@
         "keyword": [
             "星座运势"
         ],
-        "url": "http://api.317ak.cn/api/qtapi/xzys/xzys",
+        "url": "http://api.317ak.cn/api/qtapi/xzys",
         "type": "image",
         "params": {
             "msg": ""


### PR DESCRIPTION
修复api.317ak.cn的请求没有携带KEY
<img width="479" height="146" alt="image" src="https://github.com/user-attachments/assets/92afecb9-3428-480f-a3b2-eabf513c43f9" />
后续可添加配置文件，指定不同API用于存放token的key，存放位置等信息。

修复响应结果为json，json里data为视频、图片等URL时不会正确下载资源的问题

## Summary by Sourcery

确保 API 请求包含正确的密钥，并正确处理包含可下载资源 URL 的 JSON 响应。

Bug 修复：
- 根据请求的基础 URL 附加配置的 API 密钥，使对 api.317ak.cn 的调用能够按预期通过身份验证。
- 当 JSON 响应字段中包含非文本类 API 的 URL 时，下载二进制资源，而不是直接返回 URL 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure API requests include the correct key and properly handle JSON responses that contain downloadable resource URLs.

Bug Fixes:
- Attach the configured API key to requests based on their base URL so calls to api.317ak.cn are authenticated as expected.
- Download binary resources when JSON response fields contain URLs for non-text APIs instead of returning the URL string.

</details>