### PR TITLE
fix: 修复 触发关键词后，仍会调用LLM模型回复“抱歉，我无法调用API”的bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,6 +176,7 @@ class APIPlugin(Star):
         if not entries:
             return
 
+        handled = False
         for entry in entries:
             entry.updated_params = await self._build_params(event, entry, args)
             try:
@@ -195,7 +196,12 @@ class APIPlugin(Star):
                 logger.error(f"data processing failed: {exc}")
                 continue
 
-            yield event.chain_result([comp])
+            if not handled:
+                # Ensure this message is exclusively handled by this plugin.
+                event.should_call_llm(True)
+                event.stop_event()
+                handled = True
+            await event.send(MessageChain([comp]))
 
             if not self.config["save_data"]:
                 data.unlink()


### PR DESCRIPTION
fix: 匹配 API entry 后阻止 LLM 二次回复，修复资源清理时序
- 匹配到 entry 时调用 stop_event() + should_call_llm(True) 独占事件
- 改 yield 为 await event.send()，确保发送完成后再 unlink
修复前：
<img width="786" height="857" alt="image" src="https://github.com/user-attachments/assets/71448004-5d03-43fb-993e-6059301511a2" />
修复后：
<img width="694" height="796" alt="image" src="https://github.com/user-attachments/assets/e1756690-2e79-4f64-8cb6-85867c9e50fd" />
修改内容：修改/main.py，修改 `astrbot_plugin_apis/main.py` 中的 `on_message` 处理逻辑，检测到关键词后禁用默认 LLM 回复链路

## Summary by Sourcery

错误修复：
- 确保与插件 API 条目匹配的消息仅由该插件专门处理，这样 LLM 将不再额外发送默认的道歉回复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure messages matching a plugin API entry are exclusively handled by the plugin so the LLM no longer sends an additional default apology response.

</details>