### PR TITLE
fix: PearAPI 域名更换

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ API聚合插件，海量免费API动态添加，热门API：看看腿、看看�
 - 倾梦API：<https://api.317ak.cn>， 此站点需注册账号获取ckey密钥！！
 - 桑帛云API：<https://api.lolimi.cn>
 - 糖豆子API：<https://api.tangdouz.com>
-- PearAPI：<https://api.pearktrue.cn>
+- PearAPI：<https://api.pearapi.ai>
 - 问情免费API：<https://free.wqwlkj.cn>
 - 龙珠API: <https://sdkapi.hhlqilongzhu.cn>

--- a/presets/api_pool_default.json
+++ b/presets/api_pool_default.json
@@ -236,7 +236,7 @@
   },
   {
     "name": "高校查询",
-    "url": "https://api.pearktrue.cn/api/college/",
+    "url": "https://api.pearapi.ai/api/college/",
     "type": "text",
     "params": {
       "keyword": "清华"
@@ -284,7 +284,7 @@
   },
   {
     "name": "黄金价格",
-    "url": "https://api.pearktrue.cn/api/goldprice/",
+    "url": "https://api.pearapi.ai/api/goldprice/",
     "type": "text",
     "params": {},
     "parse": "data[]",
@@ -446,7 +446,7 @@
   },
   {
     "name": "今天吃什么",
-    "url": "https://api.pearktrue.cn/api/today/food.php",
+    "url": "https://api.pearapi.ai/api/today/food.php",
     "type": "text",
     "params": {},
     "parse": "food",
@@ -1130,7 +1130,7 @@
   },
   {
     "name": "三坑少女",
-    "url": "https://api.pearktrue.cn/api/beautifulgirl/?type=image",
+    "url": "https://api.pearapi.ai/api/beautifulgirl/?type=image",
     "type": "image",
     "params": {},
     "parse": "",
@@ -1321,7 +1321,7 @@
   },
   {
     "name": "御姐撒娇",
-    "url": "https://api.pearktrue.cn/api/yujie/?type=mp3",
+    "url": "https://api.pearapi.ai/api/yujie/?type=mp3",
     "type": "audio",
     "params": {},
     "parse": "audiopath",
@@ -1430,7 +1430,7 @@
   },
   {
     "name": "Linux命令",
-    "url": "https://api.pearktrue.cn/api/linux/",
+    "url": "https://api.pearapi.ai/api/linux/",
     "type": "text",
     "params": {
       "keyword": ""

--- a/presets/site_pool_default.json
+++ b/presets/site_pool_default.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "纯净API",
-    "url": "https://api.pearktrue.cn",
+    "url": "https://api.pearapi.ai",
     "headers": {},
     "keys": {},
     "timeout": 60,


### PR DESCRIPTION
## Summary by Sourcery

将 PearAPI 切换至新的 pearapi.ai 域名。

Bug Fixes:
- 更新 README 中 PearAPI 的服务域名。

Chores:
- 同步更新默认 API 与站点池配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 PearAPI 切换至新的 pearapi.ai 域名。

Bug Fixes:
- 更新 README 中 PearAPI 的服务域名。

Chores:
- 同步更新默认 API 与站点池配置。

</details>